### PR TITLE
Resolve rebase failure

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -113,7 +113,7 @@ runs:
         success() && (
            steps.changed-plantuml-files.outputs.modified_files != ''
         || steps.changed-plantuml-files.outputs.orphaned_files != '')
-      uses: stefanzweifel/git-auto-commit-action@v4.15.3
+      uses: stefanzweifel/git-auto-commit-action@v5.0.0
       with:
         commit_message: "Update SVG images for PlantUML diagrams"
         branch: ${{ github.head_ref }}

--- a/action.yaml
+++ b/action.yaml
@@ -113,7 +113,7 @@ runs:
         success() && (
            steps.changed-plantuml-files.outputs.modified_files != ''
         || steps.changed-plantuml-files.outputs.orphaned_files != '')
-      uses:  stefanzweifel/git-auto-commit-action@v4.15.3
+      uses: stefanzweifel/git-auto-commit-action@v4.15.3
       with:
         commit_message: "Update SVG images for PlantUML diagrams"
         branch: ${{ github.head_ref }}

--- a/scripts/get-commitish.sh
+++ b/scripts/get-commitish.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -o pipefail
+set +o histexpand
+shopt -s expand_aliases
 
 GITHUB_EVENT_BEFORE=$1
 GITHUB_SHA=$2
 
 # create file descriptor 9 to shortcut redirection to STDERR
 exec 9>&2
+
+alias select_sha='awk '"'"'$2 ~ /\(origin/{printf $1;exit}'"'"' || (exit_code=$?; [ $exit_code -eq 141 ] && : || exit $exit_code)'
 
 echo Searching branch for new PUML files ... >&9
 echo Previous commit SHA: "'$GITHUB_EVENT_BEFORE'" >&9
@@ -19,16 +23,23 @@ if [[ "$GITHUB_EVENT_BEFORE" == "" || "$GITHUB_EVENT_BEFORE" == "000000000000000
   # first match we want to print. The last part of this command traps
   # that exit code and ignores it, while letting other exit codes
   # fail the shell command.
-  PARENT_BRANCH_SHA=`git --no-pager log --decorate | awk '$1 ~ /^commit/ && $2 ~ /[a-z0-9]+/ && $3 ~ /\(origin/{printf $2;exit}' || (exit_code=$?; [ $exit_code -eq 141 ] && : || exit $exit_code)`
+  PARENT_BRANCH_SHA=`git --no-pager log --pretty=oneline --decorate | select_sha`
   COMMITISH="$PARENT_BRANCH_SHA..HEAD"
 else
   echo Workflow was triggered by a push event. >&9
   echo Detected PUML files will contain only PUML files committed since the previous push. >&9
+
+  # It's possible this event was triggered by a rebase
+  # followed by a push, in which case the "before"  SHA
+  # is invalid. This selects the new "parent" SHA.
+  if ! git branch "$GITHUB_SHA" --contains "$GITHUB_EVENT_BEFORE" > /dev/null 2>&1; then
+    echo Detected invalid previous commit SHA. Determining new parent SHA ... >&9
+    GITHUB_EVENT_BEFORE=`git --no-pager log -g --pretty=oneline --decorate | select_sha`
+  fi
+
   COMMITISH="$GITHUB_EVENT_BEFORE..$GITHUB_SHA"
 fi
 
-# TODO remove this - for testing
-#COMMITISH=0dc2e225ea889cb40deac752d20099cc5400d252..HEAD
 echo Detected range of relevant commits are $COMMITISH >&9
 # this is an output of the action step
 echo -n $COMMITISH

--- a/scripts/get-commitish.sh
+++ b/scripts/get-commitish.sh
@@ -30,7 +30,7 @@ else
   echo Detected PUML files will contain only PUML files committed since the previous push. >&9
 
   # It's possible this event was triggered by a rebase
-  # followed by a push, in which case the "before"  SHA
+  # followed by a push, in which case the "before" SHA
   # is invalid. This selects the new "parent" SHA.
   if ! git branch "$GITHUB_SHA" --contains "$GITHUB_EVENT_BEFORE" > /dev/null 2>&1; then
     echo Detected invalid previous commit SHA. Determining new parent SHA ... >&9


### PR DESCRIPTION
This resolves an issue caused by a rebase invalidating the commit that GitHub Actions receives as the previous commit during a push action following that rebase.