### PR TITLE
Prepare for version `1.0.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,33 @@
 # Changelog
+
 All notable changes to tool-PlantUML-action.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
----
-## [Unreleased]
+## [1.0.2] - 2024-10-18
+
 ### Fixed
+
 - Fixed issue with invalid file modification list #1
 
 ## [1.0.1] - 2024-03-13
+
 ### Fixed
+
 - Resolved failure involving rebases when Action is triggered #3
 
 ## [1.0.0] - 2023-02-01
+
 ### Added
+
 - PlantUML SVG generation action
+
 ### Changed
+
 - Updated meta information (readme, license, etc.)
+
+[1.0.0]: https://github.com/uclahs-cds/tool-PlantUML-action/releases/tag/v1.0.0
+[1.0.1]: https://github.com/uclahs-cds/tool-PlantUML-action/compare/v1.0.0...v1.0.1
+[1.0.2]: https://github.com/uclahs-cds/tool-PlantUML-action/compare/v1.0.1...v1.0.2


### PR DESCRIPTION
Update CHANGELOG in preparation for release **1.0.2**.

Merging this PR will trigger another workflow to create the release tag **v1.0.2**.

| Input | Value |
| ----- | ----- |
| Actor | @nwiltsie |
| Branch | `main` |
| Bump Type | `patch` |
